### PR TITLE
BGP af merge, with enhancements to utilitylib

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,11 +663,13 @@ Manages configuration of a BGP instance.
 | `disable_policy_batching` | Not supported on IOS XR |
 | `disable_policy_batching_ipv4` | Not supported on N56xx, N6k, N7k, IOS XR |
 | `disable_policy_batching_ipv6` | Not supported on N56xx, N6k, N7k, IOS XR |
+| `enforce_first_as` | Only supported in global BGP context in NX-OS |
 | `event_history_cli` | Not supported on IOS XR |
 | `event_history_detail` | Not supported on IOS XR |
 | `event_history_events` | Not supported on IOS XR |
 | `event_history_periodic` | Not supported on IOS XR |
-| `flush_routes` | Not supported on IOS XR |
+| `fast_external_fallover` | Only supported in global BGP context in NX-OS |
+| `flush_routes` | Only supported in global BGP context in NX-OS. Not supported on IOS XR |
 | `graceful_restart` | Only supported in global BGP context in IOS XR |
 | `graceful_restart_helper` | Not supported on IOS XR |
 | `graceful_restart_timers_restart` | Only supported in global BGP context in IOS XR |
@@ -726,7 +728,7 @@ Enable/Disable the batching evaluation of prefix advertisements to all peers wit
 Enable/Disable the batching evaluation of prefix advertisements to all peers with prefix list. Valid values are String, keyword 'default'. This property is not supported on IOS XR.
 
 ##### `enforce_first_as`
-Enable/Disable enforces the neighbor autonomous system to be the first AS number listed in the AS path attribute for eBGP. Valid values are 'true', 'false', and 'default'.
+Enable/Disable enforces the neighbor autonomous system to be the first AS number listed in the AS path attribute for eBGP. Valid values are 'true', 'false', and 'default'. On NX-OS, this property is only supported in the global BGP context.
 
 ##### `event_history_cli`
 Enable/Disable cli event history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. This property is not supported on IOS XR.
@@ -741,10 +743,10 @@ Enable/Disable event history buffer. Valid values are 'true', 'false', 'size_sma
 Enable/Disable periodic event history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. This property is not supported on IOS XR.
 
 ##### `fast_external_fallover`
-Enable/Disable immediately reset the session if the link to a directly connected BGP peer goes down. Valid values are 'true', 'false', and 'default'.
+Enable/Disable immediately reset the session if the link to a directly connected BGP peer goes down. Valid values are 'true', 'false', and 'default'. On NX-OS, this property is only supported in the global BGP context.
 
 ##### `flush_routes`
-Enable/Disable flush routes in RIB upon controlled restart. Valid values are 'true', 'false', and 'default'. This property is not supported on IOS XR.
+Enable/Disable flush routes in RIB upon controlled restart. Valid values are 'true', 'false', and 'default'. On NX-OS, this property is only supported in the global BGP context. This property is not supported on IOS XR.
 
 ##### `isolate`
 Enable/Disable isolate this router from BGP perspective. Valid values are 'true', 'false', and 'default'. This property is not supported on IOS XR.

--- a/tests/beaker_tests/cisco_bgp/test_bgp.rb
+++ b/tests/beaker_tests/cisco_bgp/test_bgp.rb
@@ -207,10 +207,13 @@ def unsupported_properties(tests, id)
       # NX-OS does not support these properties under a non-default vrf
       unprops <<
         :disable_policy_batching <<
+        :enforce_first_as <<
         :event_history_cli <<
         :event_history_detail <<
         :event_history_events <<
         :event_history_periodic <<
+        :fast_external_fallover <<
+        :flush_routes <<
         :neighbor_down_fib_accelerate
     end
   end

--- a/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
+++ b/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
@@ -22,174 +22,7 @@
 #
 ###############################################################################
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
-<<<<<<< HEAD
 require File.expand_path('../../cisco_bgp/bgplib.rb', __FILE__)
-require File.expand_path('../bgpaflib.rb', __FILE__)
-# -----------------------------
-# Common settings and variables
-# -----------------------------
-testheader = 'Resource cisco_bgp_af :: All default property values'
-
-# The 'tests' hash is used to define all of the test data values and expected
-# results. It is also used to pass optional flags to the test methods when
-# necessary.
-
-# 'tests' hash
-# Top-level keys set by caller:
-# tests[:master] - the master object
-# tests[:agent] - the agent object
-#
-tests = {
-  :master => master,
-  :agent  => agent,
-}
-
-# tests[id] keys set by caller and used by test_harness_common:
-#
-# tests[id] keys set by caller:
-# tests[id][:desc] - a string to use with logs & debugs
-# tests[id][:manifest] - the complete manifest, as used by test_harness_common
-# tests[id][:resource] - a hash of expected states, used by test_resource
-# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
-# tests[id][:ensure] - (Optional) set to :present or :absent before calling
-# tests[id][:code] - (Optional) override the default exit code in some tests.
-#
-# These keys are local use only and not used by test_harness_common:
-#
-# tests[id][:manifest_props] - This is essentially a master list of properties
-#   that permits re-use of the properties for both :present and :absent testing
-#   without destroying the list
-# tests[id][:resource_props] - This is essentially a master hash of properties
-#   that permits re-use of the properties for both :present and :absent testing
-#   without destroying the hash
-# tests[id][:title_pattern] - (Optional) defines the manifest title.
-#   Can be used with :af for mixed title/af testing. If mixing, :af values will
-#   be merged with title values and override any duplicates. If omitted,
-#   :title_pattern will be set to 'id'.
-# tests[id][:remote_as] - (Optional) allows explicit remote-as configuration
-#   for some ebgp/ibgp-only testing
-
-# default_properties
-#
-
-def remove_property(prop_symbol, test)
-  test[:manifest_props].delete(prop_symbol)
-  test[:resource_props].delete(prop_symbol.to_s)
-end
-
-def remove_unsupported_properties(test, platform, vrf)
-  if platform == 'ios_xr' # remove properties not supported on XR
-    remove_property(:additional_paths_install, test)
-    remove_property(:advertise_l2vpn_evpn, test)
-    remove_property(:dampen_igp_metric, test)
-    remove_property(:default_information_originate, test)
-    remove_property(:default_metric, test)
-    remove_property(:inject_map, test)
-    remove_property(:suppress_inactive, test)
-    remove_property(:table_map_filter, test)
-
-    # properties that are not supported under a vrf
-    if vrf != 'default'
-      remove_property(:client_to_client, test)
-      remove_property(:dampening_state, test)
-      remove_property(:dampening_half_time, test)
-      remove_property(:dampening_max_suppress_time, test)
-      remove_property(:dampening_reuse_time, test)
-      remove_property(:dampening_suppress_time, test)
-      remove_property(:next_hop_route_map, test)
-    end
-  end
-
-  return unless vrf == 'default'
-
-  # properties that are ONLY supported under a vrf
-  remove_property(:advertise_l2vpn_evpn, test)
-end
-
-def test_default_properties(tests, platform, vrf, desc, present=true)
-  id = 'default_properties'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :additional_paths_install      => 'default',
-      :additional_paths_receive      => 'default',
-      :additional_paths_selection    => 'default',
-      :additional_paths_send         => 'default',
-      :advertise_l2vpn_evpn          => 'default',
-      :client_to_client              => 'default',
-      :dampen_igp_metric             => 'default',
-      :dampening_state               => 'default',
-      :dampening_half_time           => 'default',
-      :dampening_max_suppress_time   => 'default',
-      :dampening_reuse_time          => 'default',
-      :dampening_suppress_time       => 'default',
-      :default_information_originate => 'default',
-      :default_metric                => 'default',
-      :distance_ebgp                 => 'default',
-      :distance_ibgp                 => 'default',
-      :distance_local                => 'default',
-      :inject_map                    => 'default',
-      :maximum_paths                 => 'default',
-      :maximum_paths_ibgp            => 'default',
-      :next_hop_route_map            => 'default',
-      :networks                      => 'default',
-      :redistribute                  => 'default',
-      :suppress_inactive             => 'default',
-      :table_map                     => 'default',
-      :table_map_filter              => 'default',
-    },
-
-    :resource_props => {
-      'additional_paths_install'      => 'false',
-      'additional_paths_receive'      => 'false',
-      'additional_paths_send'         => 'false',
-      'advertise_l2vpn_evpn'          => 'false',
-      'client_to_client'              => 'true',
-      'dampen_igp_metric'             => '600',
-      'dampening_state'               => 'true',
-      'dampening_half_time'           => '15',
-      'dampening_max_suppress_time'   => '45',
-      'dampening_reuse_time'          => '750',
-      'dampening_suppress_time'       => '2000',
-      'default_information_originate' => 'false',
-      'distance_ebgp'                 => '20',
-      'distance_ibgp'                 => '200',
-      'distance_local'                => '220',
-      'maximum_paths'                 => '1',
-      'maximum_paths_ibgp'            => '1',
-      'suppress_inactive'             => 'false',
-      'table_map_filter'              => 'false',
-    },
-  }
-  tests[id][:ensure] = :absent unless present
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_default_dampening_routemap(tests, platform, vrf, desc)
-  id = 'default_properties'
-
-  # Special case: When dampening_routemap is set to default
-  # it means that dampening is enabled without routemap.
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :dampening_routemap => 'default'
-    },
-
-    :resource_props => {
-      'dampening_state'             => 'true',
-      'dampening_half_time'         => '15',
-      'dampening_max_suppress_time' => '45',
-      'dampening_reuse_time'        => '750',
-      'dampening_suppress_time'     => '2000',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-=======
 
 # Test hash top-level keys
 tests = {
@@ -202,7 +35,7 @@ tests = {
 tests[:default] = {
   desc:           '1.1 Default Properties',
   preclean:       'cisco_bgp',
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     additional_paths_install:      'default',
     additional_paths_receive:      'default',
@@ -256,7 +89,7 @@ tests[:default] = {
 # it means that dampening is enabled without routemap.
 tests[:default_dampening_routemap] = {
   desc:           '1.2 Default dampening_routemap',
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     dampening_routemap: 'default'
   },
@@ -268,282 +101,14 @@ tests[:default_dampening_routemap] = {
     'dampening_suppress_time'     => '2000',
   },
 }
->>>>>>> develop
 
 #
 # non_default_properties
 #
-<<<<<<< HEAD
-def test_non_default_a(tests, platform, vrf, desc)
-  id = 'non_default_properties_A'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :additional_paths_install   => true,
-      :additional_paths_receive   => true,
-      :additional_paths_selection => 'RouteMap',
-      :additional_paths_send      => true,
-      :advertise_l2vpn_evpn       => true,
-    },
-
-    :resource_props => {
-      'additional_paths_install'   => 'true',
-      'additional_paths_receive'   => 'true',
-      'additional_paths_selection' => 'RouteMap',
-      'additional_paths_send'      => 'true',
-      'advertise_l2vpn_evpn'       => 'true',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_c(tests, platform, vrf, desc)
-  id = 'non_default_properties_C'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :client_to_client => false
-    },
-
-    :resource_props => {
-      'client_to_client' => 'false'
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_d(tests, platform, vrf, desc)
-  id = 'non_default_properties_D'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :dampen_igp_metric             => 200,
-      :dampening_half_time           => 1,
-      :dampening_max_suppress_time   => 4,
-      :dampening_reuse_time          => 2,
-      :dampening_suppress_time       => 3,
-      :default_information_originate => true,
-      :default_metric                => 50,
-      :distance_ebgp                 => 30,
-      :distance_ibgp                 => 60,
-      :distance_local                => 90,
-    },
-
-    :resource_props => {
-      'dampen_igp_metric'             => '200',
-      'dampening_half_time'           => '1',
-      'dampening_max_suppress_time'   => '4',
-      'dampening_reuse_time'          => '2',
-      'dampening_suppress_time'       => '3',
-      'default_information_originate' => 'true',
-      'default_metric'                => '50',
-      'distance_ebgp'                 => '30',
-      'distance_ibgp'                 => '60',
-      'distance_local'                => '90',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-# Special case: Just dampening_state, no properties.
-def test_non_default_dampening_true(tests, platform, vrf, desc)
-  id = 'non_default_properties_Dampening_true'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :dampening_state => 'true'
-    },
-
-    :resource_props => {
-      'dampening_state'             => 'true',
-      'dampening_half_time'         => '15',
-      'dampening_max_suppress_time' => '45',
-      'dampening_reuse_time'        => '750',
-      'dampening_suppress_time'     => '2000',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_dampening_false(tests, platform, vrf, desc)
-  id = 'non_default_properties_Dampening_false'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :dampening_state => 'false'
-    },
-
-    :resource_props => {
-      'dampening_state' => 'false'
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-# Special case: When dampening_routemap is mutually exclusive
-# with other dampening properties.
-def test_non_default_dampening_routemap(tests, platform, vrf, desc)
-  id = 'non_default_properties_Dampening_routemap'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :dampening_routemap => 'RouteMap'
-    },
-
-    :resource_props => {
-      'dampening_routemap' => 'RouteMap'
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_i(tests, platform, vrf, desc)
-  injectmap = [['nyc', 'sfo'], ['sjc', 'sfo', 'copy-attributes']] # rubocop:disable Style/WordArray
-  id = 'non_default_properties_I'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :inject_map => injectmap
-    },
-
-    :resource_props => {
-      'inject_map' => "#{injectmap}"
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_m(tests, platform, vrf, desc)
-  id = 'non_default_properties_M'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :maximum_paths      => 9,
-      :maximum_paths_ibgp => 9,
-    },
-
-    :resource_props => {
-      'ensure'             => 'present',
-      'maximum_paths'      => '9',
-      'maximum_paths_ibgp' => '9',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_n(tests, platform, vrf, desc)
-  id = 'non_default_properties_N'
-  networks = [['192.168.5.0/24', 'RouteMap'], ['192.168.6.0/32']]
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :networks           => networks,
-      :next_hop_route_map => 'RouteMap',
-    },
-
-    :resource_props => {
-      'networks'           => "#{networks}",
-      'next_hop_route_map' => 'RouteMap',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_r(tests, platform, vrf, desc)
-  id = 'non_default_properties_R'
-  redistribute = [['static', 'RouteMap'], ['eigrp 1', 'RouteMap']] # rubocop:disable Style/WordArray
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :redistribute => redistribute
-    },
-
-    :resource_props => {
-      'redistribute' => "#{redistribute}"
-    },
-  }
-
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_s(tests, platform, vrf, desc)
-  id = 'non_default_properties_S'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :suppress_inactive => true
-    },
-
-    :resource_props => {
-      'suppress_inactive' => 'true'
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-def test_non_default_t(tests, platform, vrf, desc)
-  id = 'non_default_properties_T'
-  tests[id] = {
-    :desc           => "#{desc} (vrf '#{vrf}')",
-    :title_pattern  => "#{BgpLib::ASN} #{vrf} ipv4 unicast",
-    :manifest_props => {
-      :table_map        => 'RouteMap',
-      :table_map_filter => 'true',
-    },
-
-    :resource_props => {
-      'table_map'        => 'RouteMap',
-      'table_map_filter' => 'true',
-    },
-  }
-  test_harness_bgp_af(tests, id, platform, vrf)
-end
-
-# test vpnv4/vpnv6 afis on XR
-def test_vpn_afis(tests, platform, desc)
-  init_bgp(master, agent) # clean slate
-
-  id = 'afi_safi'
-
-  # list of [global af, vrf af] pairs to test
-  afis = %w(vpnv4 vpnv6)
-  safis = %w(unicast multicast)
-
-  afis.each do |afi|
-    # create a global AF and a vrf AF
-    safis.each do |safi|
-      tests[id] = {
-        :desc           => "#{desc}: (#{afi} #{safi})",
-        :title_pattern  => "#{BgpLib::ASN} default #{afi} #{safi}",
-        :ensure         => :present,
-        :manifest_props => {},
-        :resource_props => { 'ensure' => 'present' },
-      }
-      tests[id][:resource_cmd] = puppet_resource_cmd(
-        bgp_title_pattern_munge(tests, id, 'bgp_af'))
-      build_manifest_bgp_af(tests, id, platform, 'default')
-
-      test_manifest(tests, id)
-      test_resource(tests, id)
-    end
-  end
-end
-=======
 tests[:non_def_A] = {
   desc:           "2.1 Non Default Properties: 'A' commands",
   preclean:       'cisco_bgp',
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     additional_paths_install:   'true',
     additional_paths_receive:   'true',
@@ -554,7 +119,7 @@ tests[:non_def_A] = {
 
 tests[:non_def_C] = {
   desc:           "2.2 Non Default Properties: 'C' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     client_to_client: 'false'
   },
@@ -562,7 +127,7 @@ tests[:non_def_C] = {
 
 tests[:non_def_D] = {
   desc:           "2.3 Non Default Properties: 'D' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     dampen_igp_metric:             '200',
     dampening_half_time:           '1',
@@ -581,7 +146,7 @@ tests[:non_def_D] = {
 tests[:non_def_Dampening_true] = {
   desc:           '2.3.1 Non-Default dampening true',
   preclean:       'cisco_bgp',
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     dampening_state: 'true'
   },
@@ -596,7 +161,7 @@ tests[:non_def_Dampening_true] = {
 
 tests[:non_def_Dampening_false] = {
   desc:           '2.3.2 Non-Default dampening false',
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     dampening_state: 'false'
   },
@@ -606,7 +171,7 @@ tests[:non_def_Dampening_false] = {
 # with other dampening properties.
 tests[:non_def_Dampening_routemap] = {
   desc:           '2.3.3 Non-Default dampening_routemap',
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     dampening_routemap: 'RouteMap'
   },
@@ -615,24 +180,24 @@ tests[:non_def_Dampening_routemap] = {
 injectmap = Array[%w(nyc sfo), %w(sjc sfo copy-attributes)]
 tests[:non_def_I] = {
   desc:           "2.4 Non Default Properties: 'I' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: { inject_map: injectmap },
   resource:       { inject_map: "#{injectmap}" },
 }
 
 tests[:non_def_M] = {
   desc:           "2.5 Non Default Properties: 'M' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     maximum_paths:      '9',
     maximum_paths_ibgp: '9',
   },
 }
 
-networks = Array[%w(192.168.5.0/24 net_map1), %w(192.168.6.0/32)]
+networks = Array[%w(192.168.5.0/24 RouteMap), %w(192.168.6.0/32)]
 tests[:non_def_N] = {
   desc:           "2.6 Non Default Properties: 'N' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     networks:           networks,
     next_hop_route_map: 'RouteMap',
@@ -643,104 +208,82 @@ tests[:non_def_N] = {
   },
 }
 
-redistribute = Array[%w(direct d_map), %w(static s_map)]
+redistribute = Array[%w(static RouteMap), %w(lisp RouteMap)]
 tests[:non_def_R] = {
   desc:           "2.7 Non Default Properties: 'R' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: { redistribute:  redistribute },
   resource:       { redistribute:  "#{redistribute}" },
 }
 
 tests[:non_def_S] = {
   desc:           "2.8 Non Default Properties: 'S' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
     suppress_inactive: 'true'
   },
 }
->>>>>>> develop
 
 tests[:non_def_T] = {
   desc:           "2.9 Non Default Properties: 'T' commands",
-  title_pattern:  '2 blue ipv4 unicast',
+  title_pattern:  '2 default ipv4 unicast',
   manifest_props: {
-    table_map:        'sjc',
+    table_map:        'RouteMap',
     table_map_filter: 'true',
   },
 }
 
-<<<<<<< HEAD
-# Search pattern for show run config testing
-def af_pattern(tests, id, af)
-  asn, vrf, afi, safi = af.values
-  if tests[id][:ensure] == :present
-    if vrf[/default/]
-      [/router bgp #{asn}/, /address-family #{afi} #{safi}/]
-    else
-      [/router bgp #{asn}/, /vrf #{vrf}/, /address-family #{afi} #{safi}/]
-    end
-  else
-    if vrf[/default/]
-      [/router bgp #{asn}/]
-    else
-      [/router bgp #{asn}/, /vrf #{vrf}/]
-    end
-  end
+# L2VPN / EVPN
+if platform[/n(5|7|9)k/]
+  tests[:default][:manifest_props][:advertise_l2vpn_evpn] = 'default'
+  tests[:default][:resource]['advertise_l2vpn_evpn'] = 'false'
+
+  tests[:non_def_A][:manifest_props][:advertise_l2vpn_evpn] = 'true'
 end
 
-# Create actual manifest for a given test scenario.
-def build_manifest_bgp_af(tests, id, platform, vrf='default')
-  manifest_props = tests[id][:manifest_props]
+tests[:title_patterns_1] = {
+  desc:          'T.1 Title Pattern',
+  preclean:      'cisco_bgp',
+  title_pattern: 'new_york',
+  title_params:  { asn: '2', vrf: 'red', afi: 'ipv4', safi: 'unicast' },
+  resource:      { 'ensure' => 'present' },
+}
 
-  # optionally merge properties from :af
-  manifest_props.merge!(tests[id][:af]) unless tests[id][:af].nil?
+tests[:title_patterns_2] = {
+  desc:          'T.2 Title Pattern',
+  title_pattern: '2',
+  title_params:  { vrf: 'blue', afi: 'ipv4', safi: 'unicast' },
+  resource:      { 'ensure' => 'present' },
+}
 
-  manifest = prop_hash_to_manifest(manifest_props)
+tests[:title_patterns_3] = {
+  desc:          'T.3 Title Pattern',
+  title_pattern: '2 cyan ipv4',
+  title_params:  { safi: 'unicast' },
+  resource:      { 'ensure' => 'present' },
+}
+
+# Overridden to properly handle dependencies for this test file.
+def dependency_manifest(tests, id)
   extra_config = ''
-  if tests[id][:ensure] == :absent
-    state = 'ensure => absent,'
-    tests[id][:resource] = { 'ensure' => 'absent' }
-  else
-    state = 'ensure => present,'
-    tests[id][:resource] = tests[id][:resource_props]
-    extra_config = get_dependency_manifest(platform, vrf, tests[id][:title_pattern])
-  end
+  if operating_system == 'ios_xr'
+    vrf = vrf(tests[id])
 
-  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
-  logger.debug("build_manifest_bgp_af :: title_pattern:\n" +
-               tests[id][:title_pattern])
-  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-  node 'default' {
-
-    #{extra_config}
-
-    cisco_bgp_af { '#{tests[id][:title_pattern]}':
-      #{state}
-      #{manifest}
-    }
-  }
-EOF"
-end
-
-# get extra manifest content to handle dependencies
-def get_dependency_manifest(platform, vrf, title_pattern)
-  extra_config = ''
-  if platform == 'ios_xr'
     # XR requires the following before a vrf AF can be configured:
     #   1. a global router_id
     #   2. a global address family
     #   3. route_distinguisher configured on the vrf
     extra_config = "
-      cisco_bgp { '#{BgpLib::ASN} default':
-        ensure                                 => present,
-        router_id                              => '1.2.3.4',
+      cisco_bgp { '2 default':
+        ensure              => present,
+        router_id           => '1.2.3.4',
       }"
 
-    parent_title = "#{BgpLib::ASN} default vpnv4 unicast"
-    if parent_title != title_pattern
+    parent_title = '2 default vpnv4 unicast'
+    if parent_title != tests[id][:title_pattern]
       extra_config += "
         cisco_bgp_af { '#{parent_title}':
-          ensure                                 => present,
+          ensure            => present,
         }"
     end
 
@@ -756,201 +299,60 @@ def get_dependency_manifest(platform, vrf, title_pattern)
 
     if vrf != 'default'
       extra_config += "
-      cisco_bgp { '#{BgpLib::ASN} #{vrf}':
-        ensure                                 => present,
-        route_distinguisher                    => auto,
+      cisco_bgp { '2 #{vrf}':
+        ensure              => present,
+        route_distinguisher => auto,
       }"
     end
   end
   extra_config
 end
 
-# Wrapper for bgp_af specific settings prior to calling the
-# common test_harness.
-def test_harness_bgp_af(tests, id, platform, vrf)
-  af = bgp_title_pattern_munge(tests, id, 'bgp_af')
-  logger.info("\n--------\nTest Case Address-Family ID: #{af}")
+# Overridden to properly handle unsupported properties for this test file.
+def unsupported_properties(tests, id)
+  unprops = []
 
-  tests[id][:ensure] = :present if tests[id][:ensure].nil?
-  tests[id][:resource_cmd] = puppet_resource_cmd(af)
+  vrf = vrf(tests[id])
+  if operating_system == 'ios_xr'
+    # IOS-XR does not support these properties
+    unprops <<
+      :additional_paths_install <<
+      :advertise_l2vpn_evpn <<
+      :dampen_igp_metric <<
+      :default_information_originate <<
+      :default_metric <<
+      :inject_map <<
+      :next_hop_route_map <<
+      :suppress_inactive <<
+      :table_map_filter
 
-  props_empty = tests[id][:manifest_props].empty?
-
-  remove_unsupported_properties(tests[id], platform, vrf)
-
-  if !props_empty && tests[id][:manifest_props].empty?
-    logger.info("Skipping '#{tests[id][:desc]}' - no supported properties remain")
-  else
-    # Build the manifest for this test
-    build_manifest_bgp_af(tests, id, platform, vrf)
-
-    test_harness_common(tests, id)
+    if vrf != 'default'
+      # IOS-XR does not support these properties under a non-default vrf
+      unprops <<
+        :client_to_client <<
+        :dampening_state <<
+        :dampening_half_time <<
+        :dampening_max_suppress_time <<
+        :dampening_reuse_time <<
+        :dampening_routemap <<
+        :dampening_suppress_time
+    end
+  elsif vrf == 'default'
+    # NX-OS does not support these properties under the default vrf
+    unprops << :advertise_l2vpn_evpn
   end
 
-  tests[id][:ensure] = nil
+  unprops
 end
-=======
-# L2VPN / EVPN
-if platform[/n(5|7|9)k/]
-  tests[:default][:manifest_props][:advertise_l2vpn_evpn] = 'default'
-  tests[:default][:resource]['advertise_l2vpn_evpn'] = 'false'
 
-  tests[:non_def_A][:manifest_props][:advertise_l2vpn_evpn] = 'true'
-end
-
-tests[:title_patterns_1] = {
-  desc:          'T.1 Title Pattern',
-  preclean:      'cisco_bgp',
-  title_pattern: 'new_york',
-  title_params:  { asn: '11.4', vrf: 'red', afi: 'ipv4', safi: 'unicast' },
-  resource:      { 'ensure' => 'present' },
-}
-
-tests[:title_patterns_2] = {
-  desc:          'T.2 Title Pattern',
-  title_pattern: '11.4',
-  title_params:  { vrf: 'blue', afi: 'ipv4', safi: 'unicast' },
-  resource:      { 'ensure' => 'present' },
-}
-
-tests[:title_patterns_3] = {
-  desc:          'T.3 Title Pattern',
-  title_pattern: '11.4 cyan ipv4',
-  title_params:  { safi: 'unicast' },
-  resource:      { 'ensure' => 'present' },
-}
->>>>>>> develop
-
-# TODO: Move to/update utilitylib.rb when test_bgpneighboraf is finished.
-def bgp_title_pattern_munge(tests, id, provider=nil)
-  title = tests[id][:title_pattern]
-  af = {}
-  props = tests[id][:manifest_props]
-  [:asn, :vrf, :neighbor, :afi, :safi].each do |key|
-    af[key] = props[key] if props.key?(key)
-  end
-
-  if title.nil?
-    puts 'no title'
-    return af
-  end
-
-  t = {}
-
-  case provider
-  when 'bgp_af'
-    t[:asn], t[:vrf], t[:afi], t[:safi] = title.split
-  when 'bgp_neighbor_af'
-    t[:asn], t[:vrf], t[:neighbor], t[:afi], t[:safi] = title.split
-  end
-  t.merge!(af)
-  t[:vrf] = 'default' if t[:vrf].nil?
-  t
+def test_harness_bgp_af_run(tests, id)
+  test_harness_run(tests, id) # test in default vrf
+  test_harness_bgp_vrf(tests, id, 'blue') # test in non-default vrf
 end
 
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
-<<<<<<< HEAD
-test_name "TestCase :: #{testheader}" do
-  platform = fact_on(agent, 'os.name')
-
-  %w(default blue).each do |vrf|
-    logger.info("\n#{'-' * 60}\nSection 1. "\
-                "Default Property Testing (vrf '#{vrf}')")
-
-    init_bgp(master, agent) # clean slate
-
-    # -----------------------------------
-    test_default_properties(tests, platform, vrf, '1.1 Ensure present')
-
-    test_default_properties(tests, platform, vrf, '1.2 Ensure absent', false)
-
-    if platform != 'ios_xr'
-      test_default_dampening_routemap(
-        tests, platform, vrf, '1.3 Test dampening')
-    end
-
-    # -------------------------------------------------------------------
-    logger.info("\n#{'-' * 60}\nSection 2. "\
-                "Non Default Property Testing (vrf '#{vrf}')")
-
-    init_bgp(master, agent) # clean slate
-
-    test_non_default_a(
-      tests, platform, vrf, "2.1 Non Default Properties: 'A' commands")
-
-    test_non_default_c(
-      tests, platform, vrf, "2.2 Non Default Properties: 'C' commands")
-
-    test_non_default_d(
-      tests, platform, vrf, "2.3 Non Default Properties: 'D' commands")
-
-    # not supported on XR under a vrf
-    if platform != 'ios_xr' || vrf == 'default'
-      test_non_default_dampening_routemap(
-        tests, platform, vrf, '2.3.1 Non-Default dampening true')
-    end
-
-    init_bgp(master, agent) # clean slate
-
-    test_non_default_dampening_true(
-      tests, platform, vrf, '2.3.2 Non-Default dampening true')
-
-    test_non_default_dampening_false(
-      tests, platform, vrf, '2.3.3 Non-Default dampening false')
-
-    test_non_default_i(
-      tests, platform, vrf, "2.4 Non Default Properties: 'I' commands")
-
-    test_non_default_m(
-      tests, platform, vrf, "2.5 Non Default Properties: 'M' commands")
-
-    test_non_default_n(
-      tests, platform, vrf, "2.6 Non Default Properties: 'N' commands")
-
-    test_non_default_r(
-      tests, platform, vrf, "2.7 Non Default Properties: 'R' commands")
-
-    test_non_default_s(
-      tests, platform, vrf, "2.8 Non Default Properties: 'S' commands")
-
-    test_non_default_t(
-      tests, platform, vrf, "2.9 Non Default Properties: 'T' commands")
-  end
-
-  # -------------------------------------------------------------------
-  logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
-  init_bgp(master, agent) # clean slate
-
-  id = 'title_patterns'
-  tests[id][:desc] = '3.1 Title Patterns'
-  tests[id][:title_pattern] = BgpLib::ASN
-  tests[id][:manifest_props] = { :afi => 'ipv4', :safi => 'unicast' }
-  test_harness_bgp_af(tests, id, platform, 'default')
-
-  # -----------------------------------
-  tests[id][:desc] = '3.2 Title Patterns'
-  tests[id][:title_pattern] = "#{BgpLib::ASN} blue"
-  tests[id][:manifest_props] = { :afi => 'ipv4', :safi => 'unicast' }
-  test_harness_bgp_af(tests, id, platform, 'blue')
-
-  # -----------------------------------
-  tests[id][:desc] = '3.3 Title Patterns'
-  tests[id][:title_pattern] = "#{BgpLib::ASN} red ipv4"
-  tests[id][:manifest_props] = { :safi => 'unicast' }
-  test_harness_bgp_af(tests, id, platform, 'red')
-
-  # -----------------------------------
-  tests[id][:desc] = '3.4 Title Patterns'
-  tests[id][:title_pattern] = "#{BgpLib::ASN} yellow ipv4 unicast"
-  tests[id][:manifest_props] = {}
-  test_harness_bgp_af(tests, id, platform, 'yellow')
-
-  test_vpn_afis(tests, platform, '3.5 VPN AFIs') if platform == 'ios_xr'
-
-  cleanup_bgp(master, agent)
-=======
 test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
@@ -966,18 +368,18 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_def_A)
-  test_harness_run(tests, :non_def_C)
-  test_harness_run(tests, :non_def_D)
-  test_harness_run(tests, :non_def_Dampening_true)
-  test_harness_run(tests, :non_def_Dampening_routemap)
-  test_harness_run(tests, :non_def_Dampening_false)
-  test_harness_run(tests, :non_def_I)
-  test_harness_run(tests, :non_def_M)
-  test_harness_run(tests, :non_def_N)
-  test_harness_run(tests, :non_def_R)
-  test_harness_run(tests, :non_def_S)
-  test_harness_run(tests, :non_def_T)
+  test_harness_bgp_af_run(tests, :non_def_A)
+  test_harness_bgp_af_run(tests, :non_def_C)
+  test_harness_bgp_af_run(tests, :non_def_D)
+  test_harness_bgp_af_run(tests, :non_def_Dampening_true)
+  test_harness_bgp_af_run(tests, :non_def_Dampening_routemap)
+  test_harness_bgp_af_run(tests, :non_def_Dampening_false)
+  test_harness_bgp_af_run(tests, :non_def_I)
+  test_harness_bgp_af_run(tests, :non_def_M)
+  test_harness_bgp_af_run(tests, :non_def_N)
+  test_harness_bgp_af_run(tests, :non_def_R)
+  test_harness_bgp_af_run(tests, :non_def_S)
+  test_harness_bgp_af_run(tests, :non_def_T)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
@@ -988,6 +390,5 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -----------------------------------
   resource_absent_cleanup(agent, 'cisco_bgp')
   skipped_tests_summary(tests)
->>>>>>> develop
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -615,6 +615,15 @@ def create_manifest_and_resource(tests, id, extra_config=nil)
   true
 end
 
+# dependency_manifest
+#
+# This method returns a string representation of a manifest that contains
+# any dependencies needed for a particular test to run.
+# Override this in a particular test file as needed.
+def dependency_manifest(_tests, _id)
+  nil # indicates no manifest dependencies
+end
+
 # unsupported_properties
 #
 # Returns an array of properties that are not supported for
@@ -647,8 +656,7 @@ end
 # - Creates manifests
 # - Creates puppet resource title strings
 # - Cleans resource
-# - Sets up additional dependencies
-def test_harness_run(tests, id, extra_config=nil)
+def test_harness_run(tests, id, extra_config=dependency_manifest(tests, id))
   return unless platform_supports_test(tests, id)
 
   tests[id][:ensure] = :present if tests[id][:ensure].nil?


### PR DESCRIPTION
Much like the new unsupported_properties method I added to utilitylib, this PR contains a new dependency_manifest method that can be overridden by a test to return manifest config for any test dependencies.

I left Helen's method of passing this dependency config into test_harness_run, which I still think can still be useful on a testcase be testcase basis.